### PR TITLE
[FEAT]#8 login api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -29,18 +29,22 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    //데이터
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'com.h2database:h2'
 
+    //롬복
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+    //암호화
+    implementation 'org.springframework.security:spring-security-crypto'
 
+    //공통
 	implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
 
-	testImplementation 'com.h2database:h2'
+
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     //데이터
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'com.h2database:h2'
 
     //롬복
@@ -40,7 +41,10 @@ dependencies {
 
     //암호화
     implementation 'org.springframework.security:spring-security-crypto'
-
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
     //공통
 	implementation 'com.github.Miche-Let:common:dev-SNAPSHOT'
 

--- a/src/main/java/com/michelet/user/application/dto/command/LoginCommand.java
+++ b/src/main/java/com/michelet/user/application/dto/command/LoginCommand.java
@@ -1,0 +1,7 @@
+package com.michelet.user.application.dto.command;
+
+public record LoginCommand(
+    String loginId,
+    String password
+) {
+}

--- a/src/main/java/com/michelet/user/application/dto/result/LoginResult.java
+++ b/src/main/java/com/michelet/user/application/dto/result/LoginResult.java
@@ -1,0 +1,7 @@
+package com.michelet.user.application.dto.result;
+
+public record LoginResult(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/com/michelet/user/application/port/PasswordEncryptor.java
+++ b/src/main/java/com/michelet/user/application/port/PasswordEncryptor.java
@@ -1,0 +1,6 @@
+package com.michelet.user.application.port;
+
+public interface PasswordEncryptor {
+    String encode(String rawPassword);
+    boolean matches(String rawPassword, String encodedPassword);
+}

--- a/src/main/java/com/michelet/user/application/port/RefreshTokenStore.java
+++ b/src/main/java/com/michelet/user/application/port/RefreshTokenStore.java
@@ -1,0 +1,8 @@
+package com.michelet.user.application.port;
+
+import java.time.Duration;
+import java.util.UUID;
+
+public interface RefreshTokenStore {
+    void save(UUID userId, String refreshToken, Duration ttl);
+}

--- a/src/main/java/com/michelet/user/application/port/TokenProvider.java
+++ b/src/main/java/com/michelet/user/application/port/TokenProvider.java
@@ -1,0 +1,11 @@
+package com.michelet.user.application.port;
+
+import java.util.UUID;
+
+public interface TokenProvider {
+    String createAccessToken(UUID userId, String role);
+    String createRefreshToken(UUID userId);
+    UUID getUserId(String token);
+    boolean isValid(String token);
+    long getRefreshTokenExpirationSeconds();
+}

--- a/src/main/java/com/michelet/user/application/service/AuthCommandService.java
+++ b/src/main/java/com/michelet/user/application/service/AuthCommandService.java
@@ -23,9 +23,9 @@ public class AuthCommandService {
 
     public LoginResult login(LoginCommand command) {
         User user = userRepository.findByLoginId(command.loginId())
-            .orElseThrow(() -> new UserException(UserErrorCode.INVALID_LOGIN_ID));
+            .orElseThrow(() -> new UserException(UserErrorCode.INVALID_CREDENTIALS));
         if (!passwordEncryptor.matches(command.password(), user.getPassword().value())) {
-            throw new UserException(UserErrorCode.INVALID_PASSWORD);
+            throw new UserException(UserErrorCode.INVALID_CREDENTIALS);
         }
 
         String accessToken = tokenProvider.createAccessToken(user.getId().value(), user.getRole().name());

--- a/src/main/java/com/michelet/user/application/service/AuthCommandService.java
+++ b/src/main/java/com/michelet/user/application/service/AuthCommandService.java
@@ -1,0 +1,41 @@
+package com.michelet.user.application.service;
+
+import com.michelet.user.application.dto.command.LoginCommand;
+import com.michelet.user.application.dto.result.LoginResult;
+import com.michelet.user.application.port.PasswordEncryptor;
+import com.michelet.user.application.port.RefreshTokenStore;
+import com.michelet.user.application.port.TokenProvider;
+import com.michelet.user.domain.exception.UserErrorCode;
+import com.michelet.user.domain.exception.UserException;
+import com.michelet.user.domain.model.User;
+import com.michelet.user.domain.repository.UserRepository;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCommandService {
+    private final PasswordEncryptor passwordEncryptor;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenStore refreshTokenStore;
+
+    public LoginResult login(LoginCommand command) {
+        User user = userRepository.findByLoginId(command.loginId())
+            .orElseThrow(() -> new UserException(UserErrorCode.INVALID_LOGIN_ID));
+        if (!passwordEncryptor.matches(command.password(), user.getPassword().value())) {
+            throw new UserException(UserErrorCode.INVALID_PASSWORD);
+        }
+
+        String accessToken = tokenProvider.createAccessToken(user.getId().value(), user.getRole().name());
+        String refreshToken = tokenProvider.createRefreshToken(user.getId().value());
+
+        refreshTokenStore.save(
+            user.getId().value(),
+            refreshToken,
+            Duration.ofSeconds( tokenProvider.getRefreshTokenExpirationSeconds()));
+
+        return new LoginResult(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/michelet/user/application/service/UserCommandService.java
+++ b/src/main/java/com/michelet/user/application/service/UserCommandService.java
@@ -11,6 +11,7 @@ import com.michelet.user.domain.vo.LoginId;
 import com.michelet.user.domain.vo.Password;
 import com.michelet.user.domain.vo.Phone;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,16 +19,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserCommandService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public UserResult signUp(SignUpCommand command){
         if(userRepository.existsByLoginIdOrEmailOrPhone(command.loginId(),command.email(), command.phone())){
             throw new UserException(UserErrorCode.DUPLICATE_USER);
         }
-
+        Password password = Password.of(command.password());
         User user = User.create(
                 LoginId.of(command.loginId()),
-                Password.of(command.password()),
+                Password.fromEncoded(passwordEncoder.encode(password.value())),
                 command.name(),
                 Email.of(command.email()),
                 Phone.of(command.phone()),

--- a/src/main/java/com/michelet/user/application/service/UserCommandService.java
+++ b/src/main/java/com/michelet/user/application/service/UserCommandService.java
@@ -2,6 +2,7 @@ package com.michelet.user.application.service;
 
 import com.michelet.user.application.dto.command.SignUpCommand;
 import com.michelet.user.application.dto.result.UserResult;
+import com.michelet.user.application.port.PasswordEncryptor;
 import com.michelet.user.domain.exception.UserErrorCode;
 import com.michelet.user.domain.exception.UserException;
 import com.michelet.user.domain.model.User;
@@ -11,7 +12,6 @@ import com.michelet.user.domain.vo.LoginId;
 import com.michelet.user.domain.vo.Password;
 import com.michelet.user.domain.vo.Phone;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserCommandService {
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final PasswordEncryptor passwordEncryptor;
 
     @Transactional
     public UserResult signUp(SignUpCommand command){
@@ -29,7 +29,7 @@ public class UserCommandService {
         Password password = Password.of(command.password());
         User user = User.create(
                 LoginId.of(command.loginId()),
-                Password.fromEncoded(passwordEncoder.encode(password.value())),
+                Password.fromEncoded(passwordEncryptor.encode(password.value())),
                 command.name(),
                 Email.of(command.email()),
                 Phone.of(command.phone()),

--- a/src/main/java/com/michelet/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/michelet/user/domain/exception/UserErrorCode.java
@@ -15,7 +15,8 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST.value(), "UR_E005", "전화번호가 유효하지 않습니다."),
     INVALID_USER_ROLE(HttpStatus.BAD_REQUEST.value(),"UR_E006","유저 권한이 유효하지 않습니다."),
     DUPLICATE_USER(HttpStatus.CONFLICT.value(),"UR_E007","이미 가입된 유저 입니다."),
-    INVALID_USER_NAME(HttpStatus.BAD_REQUEST.value(), "UR_E008","유저 이름이 유효하지 않습니다.");
+    INVALID_USER_NAME(HttpStatus.BAD_REQUEST.value(), "UR_E008","유저 이름이 유효하지 않습니다."),
+    INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST.value(), "UR_E009","계정 정보가 유효하지 않습니다.");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/com/michelet/user/domain/model/User.java
+++ b/src/main/java/com/michelet/user/domain/model/User.java
@@ -4,13 +4,16 @@ import com.michelet.user.domain.enums.UserRole;
 import com.michelet.user.domain.enums.UserStatus;
 import com.michelet.user.domain.exception.UserErrorCode;
 import com.michelet.user.domain.exception.UserException;
-import com.michelet.user.domain.vo.*;
+import com.michelet.user.domain.vo.Email;
+import com.michelet.user.domain.vo.LoginId;
+import com.michelet.user.domain.vo.Password;
+import com.michelet.user.domain.vo.Phone;
+import com.michelet.user.domain.vo.UserId;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -69,7 +72,7 @@ public class User {
         return new User(
                 UserId.of(userId),
                 LoginId.of(loginId),
-                Password.of(password),
+                Password.fromEncoded(password),
                 name,
                 Email.of(email),
                 Phone.of(phone),

--- a/src/main/java/com/michelet/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/michelet/user/domain/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package com.michelet.user.domain.repository;
 
 import com.michelet.user.domain.model.User;
+import java.util.Optional;
 
 public interface UserRepository {
     boolean existsByLoginIdOrEmailOrPhone(String loginId,String email, String phone);
     User save(User user);
+    Optional<User> findByLoginId(String loginId);
 }

--- a/src/main/java/com/michelet/user/domain/vo/Password.java
+++ b/src/main/java/com/michelet/user/domain/vo/Password.java
@@ -3,11 +3,11 @@ package com.michelet.user.domain.vo;
 import com.michelet.user.domain.exception.UserErrorCode;
 import com.michelet.user.domain.exception.UserException;
 
-public record Password(
-        String value
-) {
-    public Password{
-        validate(value);
+public class Password{
+    private final String value;
+
+    private Password(String value){
+        this.value = value;
     }
     public static Password of(String value){
         validateRaw(value);
@@ -17,6 +17,10 @@ public record Password(
         validate(value);
         return new Password(value);
     }
+    public String value(){
+        return value;
+    }
+
     private static void validate(String value){
         if(value== null || value.isBlank())
             throw new UserException(UserErrorCode.INVALID_PASSWORD);

--- a/src/main/java/com/michelet/user/domain/vo/Password.java
+++ b/src/main/java/com/michelet/user/domain/vo/Password.java
@@ -10,13 +10,21 @@ public record Password(
         validate(value);
     }
     public static Password of(String value){
+        validateRaw(value);
         return new Password(value);
     }
-    private void validate(String value){
+    public static Password fromEncoded(String value){
+        validate(value);
+        return new Password(value);
+    }
+    private static void validate(String value){
         if(value== null || value.isBlank())
             throw new UserException(UserErrorCode.INVALID_PASSWORD);
+    }
+    private static void validateRaw(String value){
+        validate(value);
         String passwordRegex =
-                "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}\\[\\]:;\"'<>,.?/]).{8,20}$";
+            "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}\\[\\]:;\"'<>,.?/]).{8,20}$";
         if(!value.matches(passwordRegex)){
             throw new UserException(UserErrorCode.INVALID_PASSWORD);
         }

--- a/src/main/java/com/michelet/user/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/michelet/user/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.michelet.user.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/michelet/user/infrastructure/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/com/michelet/user/infrastructure/persistence/jpa/UserJpaRepository.java
@@ -1,8 +1,10 @@
 package com.michelet.user.infrastructure.persistence.jpa;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<UserJpaEntity, UUID> {
     boolean existsByLoginIdOrEmailOrPhone(String loginId, String email, String phone);
+    Optional<UserJpaEntity> findByLoginId(String loginId);
 }

--- a/src/main/java/com/michelet/user/infrastructure/persistence/jpa/UserRepositoryImpl.java
+++ b/src/main/java/com/michelet/user/infrastructure/persistence/jpa/UserRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.michelet.user.domain.exception.UserErrorCode;
 import com.michelet.user.domain.exception.UserException;
 import com.michelet.user.domain.model.User;
 import com.michelet.user.domain.repository.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
@@ -26,5 +27,10 @@ public class UserRepositoryImpl implements UserRepository {
         } catch (DataIntegrityViolationException e) {
             throw new UserException(UserErrorCode.DUPLICATE_USER);
         }
+    }
+
+    @Override
+    public Optional<User> findByLoginId(String loginId) {
+        return jpaRepository.findByLoginId(loginId).map(UserMapper::toDomainEntity);
     }
 }

--- a/src/main/java/com/michelet/user/infrastructure/redis/RedisRefreshTokenStore.java
+++ b/src/main/java/com/michelet/user/infrastructure/redis/RedisRefreshTokenStore.java
@@ -1,0 +1,14 @@
+package com.michelet.user.infrastructure.redis;
+
+import com.michelet.user.application.port.RefreshTokenStore;
+import java.time.Duration;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisRefreshTokenStore implements RefreshTokenStore {
+    @Override
+    public void save(UUID userId, String refreshToken, Duration ttl) {
+
+    }
+}

--- a/src/main/java/com/michelet/user/infrastructure/redis/RedisRefreshTokenStore.java
+++ b/src/main/java/com/michelet/user/infrastructure/redis/RedisRefreshTokenStore.java
@@ -3,12 +3,22 @@ package com.michelet.user.infrastructure.redis;
 import com.michelet.user.application.port.RefreshTokenStore;
 import java.time.Duration;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class RedisRefreshTokenStore implements RefreshTokenStore {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
     @Override
     public void save(UUID userId, String refreshToken, Duration ttl) {
+        stringRedisTemplate.opsForValue().set(key(userId),refreshToken,ttl);
+    }
 
+    private String key(UUID userId){
+        return "refresh:"+userId;
     }
 }

--- a/src/main/java/com/michelet/user/infrastructure/security/BCryptPasswordEncryptor.java
+++ b/src/main/java/com/michelet/user/infrastructure/security/BCryptPasswordEncryptor.java
@@ -1,0 +1,23 @@
+package com.michelet.user.infrastructure.security;
+
+import com.michelet.user.application.port.PasswordEncryptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BCryptPasswordEncryptor implements PasswordEncryptor {
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public String encode(String rawPassword) {
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    @Override
+    public boolean matches(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+}

--- a/src/main/java/com/michelet/user/infrastructure/security/JwtTokenProvider.java
+++ b/src/main/java/com/michelet/user/infrastructure/security/JwtTokenProvider.java
@@ -1,33 +1,83 @@
 package com.michelet.user.infrastructure.security;
 
 import com.michelet.user.application.port.TokenProvider;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
 import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider implements TokenProvider {
+
+    private final SecretKey secretkey;
+    private final long accessTokenExpirationSeconds;
+    private final long refreshTokenExpirationSeconds;
+
+    public JwtTokenProvider(
+        @Value("&{jwt.secret}") String secret,
+        @Value("&{jwt.access-token-expiration-seconds}") long accessTokenExpirationSeconds,
+        @Value("&{jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds
+    ){
+        this.secretkey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpirationSeconds = accessTokenExpirationSeconds;
+        this.refreshTokenExpirationSeconds = refreshTokenExpirationSeconds;
+    }
+
     @Override
     public String createAccessToken(UUID userId, String role) {
-        return "";
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim("role",role)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plusSeconds(accessTokenExpirationSeconds)))
+            .signWith(secretkey)
+            .compact();
     }
 
     @Override
     public String createRefreshToken(UUID userId) {
-        return "";
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plusSeconds(refreshTokenExpirationSeconds)))
+            .signWith(secretkey)
+            .compact();
     }
 
     @Override
     public UUID getUserId(String token) {
-        return null;
+        String subject = Jwts.parser()
+            .verifyWith(secretkey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getSubject();
+        return UUID.fromString(subject);
     }
 
     @Override
     public boolean isValid(String token) {
-        return false;
+        try{
+            Jwts.parser().verifyWith(secretkey)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @Override
     public long getRefreshTokenExpirationSeconds() {
-        return 0;
+        return refreshTokenExpirationSeconds;
     }
 }

--- a/src/main/java/com/michelet/user/infrastructure/security/JwtTokenProvider.java
+++ b/src/main/java/com/michelet/user/infrastructure/security/JwtTokenProvider.java
@@ -19,9 +19,9 @@ public class JwtTokenProvider implements TokenProvider {
     private final long refreshTokenExpirationSeconds;
 
     public JwtTokenProvider(
-        @Value("&{jwt.secret}") String secret,
-        @Value("&{jwt.access-token-expiration-seconds}") long accessTokenExpirationSeconds,
-        @Value("&{jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds
+        @Value("${jwt.secret}") String secret,
+        @Value("${jwt.access-token-expiration-seconds}") long accessTokenExpirationSeconds,
+        @Value("${jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds
     ){
         this.secretkey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessTokenExpirationSeconds = accessTokenExpirationSeconds;

--- a/src/main/java/com/michelet/user/infrastructure/security/JwtTokenProvider.java
+++ b/src/main/java/com/michelet/user/infrastructure/security/JwtTokenProvider.java
@@ -1,0 +1,33 @@
+package com.michelet.user.infrastructure.security;
+
+import com.michelet.user.application.port.TokenProvider;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider implements TokenProvider {
+    @Override
+    public String createAccessToken(UUID userId, String role) {
+        return "";
+    }
+
+    @Override
+    public String createRefreshToken(UUID userId) {
+        return "";
+    }
+
+    @Override
+    public UUID getUserId(String token) {
+        return null;
+    }
+
+    @Override
+    public boolean isValid(String token) {
+        return false;
+    }
+
+    @Override
+    public long getRefreshTokenExpirationSeconds() {
+        return 0;
+    }
+}

--- a/src/main/java/com/michelet/user/presentation/UserSuccessCode.java
+++ b/src/main/java/com/michelet/user/presentation/UserSuccessCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserSuccessCode implements SuccessCode {
-    USER_CREATED(HttpStatus.CREATED, "US_S001", "회원가입에 성공하였습니다.");
+    USER_CREATED(HttpStatus.CREATED, "US_S001", "회원가입에 성공하였습니다."),
+    LOGIN_SUCCEED(HttpStatus.OK, "US_S002", "로그인에 성공하였습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/michelet/user/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/michelet/user/presentation/dto/request/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.michelet.user.presentation.dto.request;
+
+import com.michelet.user.application.dto.command.LoginCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank(message = "아이디를 입력해주세요.")
+    String loginId,
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {
+    public LoginCommand toCommand(){
+        return new LoginCommand(loginId,password);
+    }
+}

--- a/src/main/java/com/michelet/user/presentation/dto/request/LoginRequest.java
+++ b/src/main/java/com/michelet/user/presentation/dto/request/LoginRequest.java
@@ -11,6 +11,6 @@ public record LoginRequest(
     String password
 ) {
     public LoginCommand toCommand(){
-        return new LoginCommand(loginId,password);
+        return new LoginCommand(loginId.trim(),password);
     }
 }

--- a/src/main/java/com/michelet/user/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/michelet/user/presentation/dto/response/LoginResponse.java
@@ -1,0 +1,6 @@
+package com.michelet.user.presentation.dto.response;
+
+public record LoginResponse(
+    String accessToken
+) {
+}

--- a/src/main/java/com/michelet/user/presentation/external/AuthApiController.java
+++ b/src/main/java/com/michelet/user/presentation/external/AuthApiController.java
@@ -1,0 +1,34 @@
+package com.michelet.user.presentation.external;
+
+import com.michelet.common.response.ApiResponse;
+import com.michelet.user.application.dto.result.LoginResult;
+import com.michelet.user.application.service.AuthCommandService;
+import com.michelet.user.presentation.UserSuccessCode;
+import com.michelet.user.presentation.dto.request.LoginRequest;
+import com.michelet.user.presentation.dto.response.LoginResponse;
+import com.michelet.user.presentation.support.TokenCookieProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/api/v1/users")
+@Controller
+@RequiredArgsConstructor
+public class AuthApiController {
+    private final AuthCommandService authCommandService;
+    private final TokenCookieProvider tokenCookieProvider;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+        LoginResult result = authCommandService.login(request.toCommand());
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, tokenCookieProvider.create(result.refreshToken()).toString())
+            .body(ApiResponse.ok(UserSuccessCode.LOGIN_SUCCEED, new LoginResponse(result.accessToken())));
+    }
+}

--- a/src/main/java/com/michelet/user/presentation/external/AuthApiController.java
+++ b/src/main/java/com/michelet/user/presentation/external/AuthApiController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@RequestMapping("/api/v1/users")
+@RequestMapping("/api/v1/auth")
 @Controller
 @RequiredArgsConstructor
 public class AuthApiController {

--- a/src/main/java/com/michelet/user/presentation/internal/UserInternalController.java
+++ b/src/main/java/com/michelet/user/presentation/internal/UserInternalController.java
@@ -1,4 +1,0 @@
-package com.michelet.user.presentation.internal;
-
-public class UserInternalController {
-}

--- a/src/main/java/com/michelet/user/presentation/support/TokenCookieProvider.java
+++ b/src/main/java/com/michelet/user/presentation/support/TokenCookieProvider.java
@@ -10,17 +10,27 @@ public class TokenCookieProvider {
 
     private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
     private final long refreshTokenExpirationSeconds;
+    private final boolean secure;
+    private final String sameSite;
+    private final String path;
 
     public TokenCookieProvider(
-        @Value("${jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds
-    ){
+        @Value("${jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds,
+        @Value("${cookie.refresh-token.secure}") boolean secure,
+        @Value("${cookie.refresh-token.same-site}") String sameSite,
+        @Value("${cookie.refresh-token.path}") String path
+    ) {
         this.refreshTokenExpirationSeconds = refreshTokenExpirationSeconds;
+        this.secure = secure;
+        this.sameSite = sameSite;
+        this.path = path;
     }
     public ResponseCookie create(String refreshToken){
         return ResponseCookie.from(REFRESH_TOKEN_COOKIE,refreshToken)
             .httpOnly(true)
-            .secure(false)
-            .path("/")
+            .secure(secure)
+            .sameSite(sameSite)
+            .path(path)
             .maxAge(Duration.ofSeconds(refreshTokenExpirationSeconds))
             .build();
     }
@@ -28,9 +38,9 @@ public class TokenCookieProvider {
     public ResponseCookie delete() {
         return ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
             .httpOnly(true)
-            .secure(false)
-            .sameSite("Lax")
-            .path("/")
+            .secure(secure)
+            .sameSite(sameSite)
+            .path(path)
             .maxAge(0)
             .build();
     }

--- a/src/main/java/com/michelet/user/presentation/support/TokenCookieProvider.java
+++ b/src/main/java/com/michelet/user/presentation/support/TokenCookieProvider.java
@@ -1,0 +1,37 @@
+package com.michelet.user.presentation.support;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenCookieProvider {
+
+    private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+    private final long refreshTokenExpirationSeconds;
+
+    public TokenCookieProvider(
+        @Value("${jwt.refresh-token-expiration-seconds}") long refreshTokenExpirationSeconds
+    ){
+        this.refreshTokenExpirationSeconds = refreshTokenExpirationSeconds;
+    }
+    public ResponseCookie create(String refreshToken){
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE,refreshToken)
+            .httpOnly(true)
+            .secure(false)
+            .path("/")
+            .maxAge(Duration.ofSeconds(refreshTokenExpirationSeconds))
+            .build();
+    }
+
+    public ResponseCookie delete() {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(0)
+            .build();
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,14 +1,18 @@
 eureka:
   client:
     service-url:
-      defaultZone: http://eureka-server:8761/eureka/
+      defaultZone: http://${EUREKA_CONTAINER_NAME}:${EUREKA_PORT}/eureka/
 
 spring:
   datasource:
-    url: jdbc:postgresql://db:5432/michelet_db
-    username: admin
-    password: admin
+    url: jdbc:postgresql://${POSTGRES_CONTAINER_NAME}:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  data:
+    redis:
+      host: ${REDIS_CONTAINER_NAME}
+      port: ${REDIS_PORT:6379}
 
   jpa:
     hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,14 +1,18 @@
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka/
+      defaultZone: http://localhost:${EUREKA_PORT}/eureka/
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/michelet_db
-    username: admin
-    password: admin
+    url: jdbc:postgresql://localhost:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  data:
+    redis:
+      host: localhost
+      port: ${REDIS_PORT:6379}
 
   jpa:
     hibernate:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,6 +6,7 @@ spring:
   cloud:
     discovery:
       enabled: false
+
   datasource:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
@@ -15,3 +16,13 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+
+  data:
+      redis:
+          host: localhost
+          port: 6379
+
+jwt:
+    secret: ${JWT_SECRET:test-secret-key-test-secret-key-test-secret-key}
+    access-token-expiration-seconds: ${JWT_ACCESS_TOKEN_EXPIRATION_SECONDS:1800}
+    refresh-token-expiration-seconds: ${JWT_REFRESH_TOKEN_EXPIRATION_SECONDS:1209600}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -17,10 +17,6 @@ spring:
     hibernate:
       ddl-auto: create-drop
 
-  data:
-      redis:
-          host: localhost
-          port: 6379
 
 jwt:
     secret: ${JWT_SECRET:test-secret-key-test-secret-key-test-secret-key}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,9 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration-seconds: ${JWT_ACCESS_TOKEN_EXPIRATION_SECONDS:1800}
   refresh-token-expiration-seconds: ${JWT_REFRESH_TOKEN_EXPIRATION_SECONDS:1209600}
+
+cookie:
+  refresh-token:
+    secure: false
+    same-site: Lax
+    path: /api/v1/auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,8 @@ spring:
 
 server:
   port: 19100
+
+jwt:
+    secret: ${JWT_SECRET}
+    access-token-expiration-seconds: ${JWT_ACCESS_TOKEN_EXPIRATION_SECONDS:1800}
+    refresh-token-expiration-seconds: ${JWT_REFRESH_TOKEN_EXPIRATION_SECONDS:1209600}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,6 @@ server:
   port: 19100
 
 jwt:
-    secret: ${JWT_SECRET}
-    access-token-expiration-seconds: ${JWT_ACCESS_TOKEN_EXPIRATION_SECONDS:1800}
-    refresh-token-expiration-seconds: ${JWT_REFRESH_TOKEN_EXPIRATION_SECONDS:1209600}
+  secret: ${JWT_SECRET}
+  access-token-expiration-seconds: ${JWT_ACCESS_TOKEN_EXPIRATION_SECONDS:1800}
+  refresh-token-expiration-seconds: ${JWT_REFRESH_TOKEN_EXPIRATION_SECONDS:1209600}

--- a/src/test/java/com/michelet/user/UserServiceApplicationTests.java
+++ b/src/test/java/com/michelet/user/UserServiceApplicationTests.java
@@ -1,11 +1,14 @@
 package com.michelet.user;
 
+import com.michelet.user.config.RedisConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
+@Import(RedisConfig.class)
 class UserServiceApplicationTests {
 
 	@Test

--- a/src/test/java/com/michelet/user/config/RedisConfig.java
+++ b/src/test/java/com/michelet/user/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.michelet.user.config;
+
+import com.michelet.user.application.port.RefreshTokenStore;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class RedisConfig {
+    @Bean
+    @Primary
+    public RefreshTokenStore refreshTokenStore() {
+        return new RefreshTokenStore() {
+            private final Map<UUID, String> store = new ConcurrentHashMap<>();
+
+            @Override
+            public void save(UUID userId, String refreshToken, Duration ttl) {
+                store.put(userId, refreshToken);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 로그인 기능 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #8  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
빌드결과
<img width="916" height="288" alt="스크린샷 2026-04-29 오후 9 16 44" src="https://github.com/user-attachments/assets/234eb1bb-bbb2-44a7-ad95-6c21f809e3ce" />

api 실행 결과
<img width="1121" height="408" alt="스크린샷 2026-04-29 오후 9 06 45" src="https://github.com/user-attachments/assets/c532ba0b-57e0-4939-b756-670a84e491e8" />
<img width="1106" height="484" alt="스크린샷 2026-04-29 오후 9 06 51" src="https://github.com/user-attachments/assets/61af3901-cc5d-4ee1-b357-09af55b35452" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 엔드포인트 추가 (POST /api/v1/auth/login)
  * JWT 액세스·리프레시 토큰 발급 및 검증, 로그인 성공 시 액세스 토큰 반환

* **보안/세션**
  * 리프레시 토큰을 HttpOnly 쿠키로 설정 및 서버에 저장(Redis 지원)
  * 비밀번호 해싱(BCrypt) 적용

* **기타**
  * .env 파일을 버전관리에서 제외
  * 로그인 성공 응답 코드/메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->